### PR TITLE
[FE-DEV] 채용공고 상세보기 UI 구현

### DIFF
--- a/src/components/employ/EmployDetail.tsx
+++ b/src/components/employ/EmployDetail.tsx
@@ -1,0 +1,55 @@
+import { useParams } from "react-router-dom";
+import data, { EmployData } from "../../data/EmployData";
+import "../../styles/employ/EmployDetail.scss";
+
+const EmployDetail = () => {
+  const { employId } = useParams();
+  const parsedStudyId = employId ? parseInt(employId) : undefined;
+  const selectedData = data.find((item) => item.employId === parsedStudyId);
+  if (!selectedData) {
+    return <div>해당 컨텐츠를 찾을 수 없습니다.</div>;
+  }
+
+  return (
+    <div className="employ-detail-container">
+      <span className="category">{selectedData.recruit}</span>
+      <h1>{selectedData.info}</h1>
+      <div className="info-container">
+        <div className="img">
+          <img src={selectedData.img} alt="logo" />
+        </div>
+        <div className="info">
+          <h2>{selectedData.company}</h2>
+          <div className="field-container">
+            <div className="field-info">
+              <h3>직무형태</h3>
+              <p>{selectedData.job_type}</p>
+            </div>
+            <div className="field-info">
+              <h3>근무지역</h3>
+              <p>{selectedData.area}</p>
+            </div>
+            <div className="field-info">
+              <h3>학력조건</h3>
+              <p>{selectedData.edu_lv}</p>
+            </div>
+            <div className="field-info">
+              <h3>직무키워드</h3>
+              <p>{selectedData.job_keywords}</p>
+            </div>
+            <div className="field-info">
+              <h3>등록일</h3>
+              <p>{selectedData.published}</p>
+            </div>
+            <div className="field-info">
+              <h3>마감일</h3>
+              <p>{selectedData.deadline}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EmployDetail;

--- a/src/components/main/MainEmploy.tsx
+++ b/src/components/main/MainEmploy.tsx
@@ -1,58 +1,37 @@
 import "../../styles/main/MainEmploy.scss";
-
-const employData = [
-  {
-    recruit: "모짐 마감",
-    deadline: "23.09.31",
-    company: "카카오(KaKao)",
-    info: "신규 서비스 플랫폼 기획자(경력) 채용",
-  },
-  {
-    recruit: "모짐 마감",
-    deadline: "23.09.31",
-    company: "카카오(KaKao)",
-    info: "신규 서비스 플랫폼 기획자(경력) 채용",
-  },
-  {
-    recruit: "모짐 마감",
-    deadline: "23.09.31",
-    company: "카카오(KaKao)",
-    info: "신규 서비스 플랫폼 기획자(경력) 채용",
-  },
-  {
-    recruit: "모짐 마감",
-    deadline: "23.09.31",
-    company: "카카오(KaKao)",
-    info: "신규 서비스 플랫폼 기획자(경력) 채용",
-  },
-  {
-    recruit: "모짐 마감",
-    deadline: "23.09.31",
-    company: "카카오(KaKao)",
-    info: "신규 서비스 플랫폼 기획자(경력) 채용",
-  },
-  {
-    recruit: "모짐 마감",
-    deadline: "23.09.31",
-    company: "카카오(KaKao)",
-    info: "신규 서비스 플랫폼 기획자(경력) 채용",
-  },
-];
+import { useNavigate, useLocation } from "react-router-dom";
+import data, { EmployData } from "../../data/EmployData";
 
 const MainEmploy = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const goEmployAll = () => {
+    navigate("/employ");
+  };
+  const goEmployItemClick = (employId: number) => {
+    navigate(`/employ/${employId}`);
+  };
+  const isEmployPath = location.pathname !== "/employ";
+
   return (
     <div>
-      <div className="title">
-        <h1>🏢 취업 정보</h1>
-      </div>
+      {isEmployPath && (
+        <div className="title">
+          <h1>🏢 취업 정보</h1>
+          <p onClick={goEmployAll}>
+            전체보기 <span>&gt;</span>
+          </p>
+        </div>
+      )}
       <div className="employ-content">
-        {employData.map((item, index) => (
-          <div className="employ-box" key={index}>
+        {data.map((item, index) => (
+          <div
+            className="employ-box"
+            key={index}
+            onClick={() => goEmployItemClick(item.employId)}
+          >
             <div className="employ-top">
-              <img
-                src="https://t1.kakaocdn.net/kakaocorp/corp_thumbnail/Kakao.png"
-                alt="img"
-              />
+              <img src={item.img} alt="img" />
             </div>
             <div className="employ-middle">
               <div>

--- a/src/data/EmployData.tsx
+++ b/src/data/EmployData.tsx
@@ -1,0 +1,97 @@
+export interface EmployData {
+  employId: number;
+  recruit: string; // 모집중 여부
+  published: string; // 등록일
+  deadline: string; // 마감일
+  company: string; // 기업명
+  img: string; // 기업 이미지
+  info: string; // 공고 내용
+  job_keywords: string; // 직무 키워드
+  job_type: string; // 직무 형태
+  area: string; // 근무지
+  edu_lv: string; // 학력 조건
+}
+
+const data: EmployData[] = [
+  {
+    employId: 1,
+    recruit: "모짐 마감",
+    published: "23.09.31",
+    deadline: "23.09.31",
+    company: "카카오(KaKao)",
+    img: "https://t1.kakaocdn.net/kakaocorp/corp_thumbnail/Kakao.png",
+    info: "신규 서비스 플랫폼 기획자(경력) 채용1",
+    job_keywords:
+      "IT 개발, 데이터, 프론트엔드, 백엔드, 데이터관리, 데이터분석, 인프라 구축",
+    job_type: "정규직",
+    area: "성남시 분당구",
+    edu_lv: "대학(4년제) 졸업",
+  },
+  {
+    employId: 2,
+    recruit: "모짐 마감",
+    published: "23.09.31",
+    deadline: "23.09.31",
+    company: "카카오(KaKao)",
+    img: "https://t1.kakaocdn.net/kakaocorp/corp_thumbnail/Kakao.png",
+    info: "신규 서비스 플랫폼 기획자(경력) 채용2",
+    job_keywords: "IT 개발, 데이터",
+    job_type: "정규직",
+    area: "성남시 분당구",
+    edu_lv: "대학(4년제) 졸업",
+  },
+  {
+    employId: 3,
+    recruit: "모짐 마감",
+    published: "23.09.31",
+    deadline: "23.09.31",
+    company: "카카오(KaKao)",
+    img: "https://t1.kakaocdn.net/kakaocorp/corp_thumbnail/Kakao.png",
+    info: "신규 서비스 플랫폼 기획자(경력) 채용3",
+    job_keywords: "IT 개발, 데이터",
+    job_type: "정규직",
+    area: "성남시 분당구",
+    edu_lv: "대학(4년제) 졸업",
+  },
+  {
+    employId: 4,
+    recruit: "모짐 마감",
+    published: "23.09.31",
+    deadline: "23.09.31",
+    company: "카카오(KaKao)",
+    img: "https://t1.kakaocdn.net/kakaocorp/corp_thumbnail/Kakao.png",
+    info: "신규 서비스 플랫폼 기획자(경력) 채용4",
+    job_keywords: "IT 개발, 데이터",
+    job_type: "정규직",
+    area: "성남시 분당구",
+    edu_lv: "대학(4년제) 졸업",
+  },
+  {
+    employId: 5,
+    recruit: "모짐 마감",
+    published: "23.09.31",
+    deadline: "23.09.31",
+    company: "카카오(KaKao)",
+    img: "https://t1.kakaocdn.net/kakaocorp/corp_thumbnail/Kakao.png",
+    info: "신규 서비스 플랫폼 기획자(경력) 채용5",
+    job_keywords: "IT 개발, 데이터",
+    job_type: "정규직",
+    area: "성남시 분당구",
+    edu_lv: "대학(4년제) 졸업",
+  },
+  {
+    employId: 6,
+    recruit: "모짐 마감",
+    published: "23.09.31",
+    deadline: "23.09.31",
+    company: "카카오(KaKao)",
+    img: "https://t1.kakaocdn.net/kakaocorp/corp_thumbnail/Kakao.png",
+    info: "신규 서비스 플랫폼 기획자(경력) 채용6",
+    job_keywords: "IT 개발, 데이터",
+    job_type: "정규직",
+    area: "성남시 분당구",
+    edu_lv: "대학(4년제) 졸업",
+  },
+];
+
+export default data;

--- a/src/pages/employ/EmployApp.tsx
+++ b/src/pages/employ/EmployApp.tsx
@@ -1,0 +1,29 @@
+import MainEmploy from "../../components/main/MainEmploy";
+import EmployDetail from "../../components/employ/EmployDetail";
+import styled from "styled-components";
+import { Routes, Route } from "react-router-dom";
+
+const EmployContainer = styled.div`
+  width: 90%;
+  min-height: 100vh;
+`;
+const EmployApp = () => {
+  return (
+    <EmployContainer>
+      <Routes>
+        <Route path="/" element={<MainEmploy />} />
+        <Route
+          path="/:employId"
+          element={
+            <>
+              <EmployDetail />
+              <MainEmploy />
+            </>
+          }
+        />
+      </Routes>
+    </EmployContainer>
+  );
+};
+
+export default EmployApp;

--- a/src/router/RouterApp.tsx
+++ b/src/router/RouterApp.tsx
@@ -2,6 +2,8 @@ import { Routes, Route, Outlet } from "react-router-dom";
 import styled from "styled-components";
 import HomeApp from "../pages/home/HomeApp";
 import MainApp from "../pages/main/MainApp";
+import EmployApp from "../pages/employ/EmployApp";
+import EmployDetail from "../components/employ/EmployDetail";
 import StudyApp from "../pages/study/StudyApp";
 import StudyDetail from "../components/study/StudyDetail";
 import CommunityApp from "../pages/community/CommunityApp";
@@ -43,6 +45,9 @@ const RouterApp = () => {
         <Route path="/home" element={<HomeApp />} />
         <Route path="/" element={<MainLayout />}>
           <Route index element={<MainApp />} />
+          <Route path="employ/*" element={<EmployApp />}>
+            <Route path=":employId" element={<EmployDetail />} />
+          </Route>
           <Route path="study/*" element={<StudyApp />}>
             <Route path=":studyId" element={<StudyDetail />} />
           </Route>

--- a/src/styles/employ/EmployDetail.scss
+++ b/src/styles/employ/EmployDetail.scss
@@ -1,0 +1,56 @@
+.employ-detail-container {
+  width: 100%;
+  border-top: 2px solid #1b1c3a;
+  border-radius: 5px;
+  box-shadow: 2px 2px 4px 0px #00000040;
+  padding: 20px;
+  margin-bottom: 50px;
+
+  h1 {
+    margin: 15px 0;
+    font-size: 1.5rem;
+  }
+
+  .info-container {
+    width: 100%;
+    display: flex;
+    gap: 40px;
+    align-items: center;
+    .img {
+      width: 200px;
+      height: 200px;
+      img {
+        width: 100%;
+        height: 100%;
+        border-radius: 5px;
+      }
+    }
+
+    .info {
+      h2 {
+        font-size: 1.2rem;
+        margin-bottom: 20px;
+      }
+      .field-container {
+        width: 500px;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+
+        .field-info {
+          display: grid;
+          grid-template-columns: 70px auto;
+          column-gap: 24px;
+          grid-template-areas: "label text";
+
+          h3,
+          p {
+            font-size: 0.9rem;
+            font-weight: 500;
+            color: #777777;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/styles/main/MainEmploy.scss
+++ b/src/styles/main/MainEmploy.scss
@@ -12,6 +12,8 @@
     height: 30vh;
     border-radius: 5px;
     border: 0.8px solid #dadada;
+    padding-bottom: 10px;
+    cursor: pointer;
 
     .employ-top {
       width: 100%;
@@ -45,8 +47,8 @@
     .employ-bottom {
       float: right;
       color: #1b1c3a;
-      font-size: 0.4rem;
-      padding: 10px 5px;
+      font-size: 0.6rem;
+      padding: 0 5px;
     }
   }
 }


### PR DESCRIPTION
1. 채용 공고 상세보기 페이지 UI 구현
  - 채용 공고에 관한 가상 데이터 파일 분리
  - 채용 공고 전체보기, 상세보기 페이지에 대한 라우터 구현
  - employId에 따른 채용 공고 상세보기 페이지 구현
  - 전체 채용공고를 볼 수 있는 MainEmploy.tsx에서 .employ-box에 대한 cursor css 추가