### PR TITLE
[FE-DEV, FIX] 회원가입, 커뮤니티(get), 스터디(get) api 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import RouterApp from "./router/RouterApp";
+import { RecoilRoot } from "recoil";
 
 function App() {
   return (
     <div className="App">
-      <RouterApp />
+      <RecoilRoot>
+        <RouterApp />
+      </RecoilRoot>
     </div>
   );
 }

--- a/src/api/fetchData.tsx
+++ b/src/api/fetchData.tsx
@@ -1,0 +1,12 @@
+import axios from "axios";
+
+const API_BASE_URL = "http://3.35.123.253/api";
+
+export const fetchData = async (endpoint: string) => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}${endpoint}`);
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/api/postData.tsx
+++ b/src/api/postData.tsx
@@ -1,0 +1,26 @@
+import axios from "axios";
+
+const API_BASE_URL = "http://3.35.123.253/api";
+
+export const postData = async (endpoint: string, data: any) => {
+  try {
+    const response = await axios.post(`${API_BASE_URL}${endpoint}`, data);
+    console.log("서버로부터의 응답:", response.data);
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const postSignUpData = async (endpoint: string, data: any) => {
+  try {
+    const response = await axios.post(`${API_BASE_URL}${endpoint}`, data);
+    console.log("서버로부터의 응답:", response.data);
+    return "성공";
+    // return response.data;
+  } catch (error: any) {
+    // console.log(error);
+    // console.log(error.request.response);
+    return "실패";
+  }
+};

--- a/src/api/postStudentCard.tsx
+++ b/src/api/postStudentCard.tsx
@@ -1,0 +1,22 @@
+import axios from "axios";
+
+const API_BASE_URL = "http://3.37.196.198:8000";
+
+export const postStudentCard = async (file: File) => {
+  // const formData = new FormData();
+  // formData.append("studentCard", file);
+  try {
+    const response = await axios.post(`${API_BASE_URL}/perform_ocr/`, file, {
+      headers: {
+        // Accept: "application/json",
+        "Content-Type": "multipart/form-data",
+      },
+    });
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    console.log(file);
+    // console.log(formData);
+  }
+};

--- a/src/components/community/CommunityDetail.tsx
+++ b/src/components/community/CommunityDetail.tsx
@@ -1,23 +1,33 @@
 import { ReactComponent as ChatIcon } from "../../assets/icon/chat-color.svg";
 import { ReactComponent as LikeIcon } from "../../assets/icon/like-color.svg";
 import { ReactComponent as ScrapIcon } from "../../assets/icon/scrap-color.svg";
-import { ReactComponent as GoodIcon } from "../../assets/icon/good.svg";
-import { ReactComponent as BadIcon } from "../../assets/icon/bad.svg";
-import { ReactComponent as UserIcon } from "../../assets/icon/user.svg";
-import { ReactComponent as ReplyIcon } from "../../assets/icon/reply.svg";
+// import { ReactComponent as GoodIcon } from "../../assets/icon/good.svg";
+// import { ReactComponent as BadIcon } from "../../assets/icon/bad.svg";
+// import { ReactComponent as UserIcon } from "../../assets/icon/user.svg";
+// import { ReactComponent as ReplyIcon } from "../../assets/icon/reply.svg";
 import { ReactComponent as SendIcon } from "../../assets/icon/send.svg";
 import "../../styles/community/CommunityDetail.scss";
-import comdata, { CommunityData } from "../../data/CommunityData";
 import { useParams, useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { CommunityData } from "../../types/Types";
+import { fetchData } from "../../api/fetchData";
 
 const CommunityDetail = () => {
   const navigate = useNavigate();
   const { contentId } = useParams();
   const parsedContentId = contentId ? parseInt(contentId) : undefined;
-  const selectedData = comdata.find(
-    (item) => item.contentId === parsedContentId
-  );
+
+  const [selectedData, setSelectedData] = useState<CommunityData>();
+
+  useEffect(() => {
+    const fetchCommunityData = async () => {
+      const data = await fetchData(`/boards/posts/${parsedContentId}/`);
+      setSelectedData(data);
+    };
+
+    fetchCommunityData();
+  }, [parsedContentId]);
+
   // 각 댓글의 좋아요/싫어요 상태를 관리하는 객체
   const [commentReactions, setCommentReactions] = useState<{
     [key: number]: {
@@ -31,47 +41,47 @@ const CommunityDetail = () => {
   if (!selectedData) {
     return <div>해당 컨텐츠를 찾을 수 없습니다.</div>;
   }
-  const commentData = selectedData?.comments || [];
+  // const commentData = selectedData?.comments || [];
 
   // 좋아요 클릭 시 색상 변경 함수
-  const handleLikeClick = (commentId: number) => {
-    setCommentReactions((prevReactions) => {
-      const originalLikeCount =
-        commentData.find((comment) => comment.commentId === commentId)?.like ||
-        0;
-      const newLikeCount = originalLikeCount + 1;
-      return {
-        ...prevReactions,
-        [commentId]: {
-          ...prevReactions[commentId],
-          likeColor: "#FF4A4A",
-          dislikeColor: "#BBBBBB",
-          currentColor: "#FF4A4A",
-          like: newLikeCount,
-        },
-      };
-    });
-  };
+  // const handleLikeClick = (commentId: number) => {
+  //   setCommentReactions((prevReactions) => {
+  //     const originalLikeCount =
+  //       commentData.find((comment) => comment.commentId === commentId)?.like ||
+  //       0;
+  //     const newLikeCount = originalLikeCount + 1;
+  //     return {
+  //       ...prevReactions,
+  //       [commentId]: {
+  //         ...prevReactions[commentId],
+  //         likeColor: "#FF4A4A",
+  //         dislikeColor: "#BBBBBB",
+  //         currentColor: "#FF4A4A",
+  //         like: newLikeCount,
+  //       },
+  //     };
+  //   });
+  // };
 
   // 싫어요 클릭 시 색상 변경 함수
-  const handleDislikeClick = (commentId: number) => {
-    setCommentReactions((prevReactions) => {
-      const originalLikeCount =
-        commentData.find((comment) => comment.commentId === commentId)?.like ||
-        0;
-      const newLikeCount = originalLikeCount - 1;
-      return {
-        ...prevReactions,
-        [commentId]: {
-          ...prevReactions[commentId],
-          likeColor: "#BBBBBB",
-          dislikeColor: "#44B0FF",
-          currentColor: "#44B0FF",
-          like: newLikeCount,
-        },
-      };
-    });
-  };
+  // const handleDislikeClick = (commentId: number) => {
+  //   setCommentReactions((prevReactions) => {
+  //     const originalLikeCount =
+  //       commentData.find((comment) => comment.commentId === commentId)?.like ||
+  //       0;
+  //     const newLikeCount = originalLikeCount - 1;
+  //     return {
+  //       ...prevReactions,
+  //       [commentId]: {
+  //         ...prevReactions[commentId],
+  //         likeColor: "#BBBBBB",
+  //         dislikeColor: "#44B0FF",
+  //         currentColor: "#44B0FF",
+  //         like: newLikeCount,
+  //       },
+  //     };
+  //   });
+  // };
 
   const goCommunity = () => {
     navigate("/community");
@@ -81,28 +91,36 @@ const CommunityDetail = () => {
     <div className="community-container">
       <div className="community-detail-container">
         <div className="detail-top">
-          <span className="category">{selectedData.category}</span>
+          <span className="category">{selectedData.category_name}</span>
           <div>
-            <p>{selectedData.date}</p>
-            <p>{selectedData.writer}</p>
+            <p>
+              {new Date(selectedData.post_date).toLocaleString("ko-KR", {
+                dateStyle: "medium",
+                timeStyle: "short",
+              })}
+            </p>
+            <p>
+              {selectedData.school_name} {selectedData.major_name}{" "}
+              {String(selectedData.admission_date).slice(-2)}학번
+            </p>
           </div>
         </div>
         <div className="detail-middle">
           <h1>{selectedData.title}</h1>
-          <p>{selectedData.content}</p>
+          <p>{selectedData.contents}</p>
         </div>
         <div className="detail-bottom">
           <div className="content-numbers">
             <ChatIcon stroke="#66BB6A" />
-            <p className="color-chat">{selectedData.chat}</p>
+            <p className="color-chat">{selectedData.comment}</p>
             <LikeIcon stroke="#FF8181" />
             <p className="color-like">{selectedData.like}</p>
             <ScrapIcon />
-            <p className="color-scrap">{selectedData.scrap}</p>
+            <p className="color-scrap">{selectedData.keep}</p>
           </div>
         </div>
       </div>
-      {commentData?.map((comment, index) => {
+      {/* {commentData?.map((comment, index) => {
         const { likeColor, dislikeColor, currentColor, like } =
           commentReactions[comment.commentId] || {
             likeColor: "#BBBBBB",
@@ -143,7 +161,7 @@ const CommunityDetail = () => {
             </div>
           </div>
         );
-      })}
+      })} */}
       <div className="community-comment-write">
         <button onClick={goCommunity}>목록으로</button>
         <div>

--- a/src/components/community/CommunityMain.tsx
+++ b/src/components/community/CommunityMain.tsx
@@ -3,19 +3,32 @@ import { ReactComponent as ChatIcon } from "../../assets/icon/chat-color.svg";
 import { ReactComponent as LikeIcon } from "../../assets/icon/like-color.svg";
 import { ReactComponent as ScrapIcon } from "../../assets/icon/scrap-color.svg";
 import { ReactComponent as PencilIcon } from "../../assets/icon/pencil.svg";
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import "../../styles/community/CommunityMain.scss";
-import comdata, { CommunityData } from "../../data/CommunityData";
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { fetchData } from "../../api/fetchData";
+import { CommunityData } from "../../types/Types";
 
 const CommunityMain: React.FC<{ onWriteButtonClick: () => void }> = ({
   onWriteButtonClick,
 }) => {
   const [selectedCategory, setSelectedCategory] = useState("전체보기");
-  const filteredData: CommunityData[] = comdata.filter(
+  const [communityData, setCommunityData] = useState<CommunityData[]>([]);
+
+  useEffect(() => {
+    const fetchCommunityData = async () => {
+      const data = await fetchData("/boards/posts/");
+      setCommunityData(data);
+    };
+
+    fetchCommunityData();
+  }, []);
+
+  const filteredData: CommunityData[] = communityData.filter(
     (item) =>
-      selectedCategory === "전체보기" || item.category === selectedCategory
+      selectedCategory === "전체보기" || item.category_name === selectedCategory
   );
+
   const navigate = useNavigate();
 
   const handleItemClick = (contentId: number) => {
@@ -37,10 +50,10 @@ const CommunityMain: React.FC<{ onWriteButtonClick: () => void }> = ({
             전체보기
           </li>
           <li
-            onClick={() => setSelectedCategory("전공질문")}
-            className={selectedCategory === "전공질문" ? "selected" : ""}
+            onClick={() => setSelectedCategory("학과질문")}
+            className={selectedCategory === "학과질문" ? "selected" : ""}
           >
-            전공질문
+            학과질문
           </li>
           <li
             onClick={() => setSelectedCategory("잡담/수다")}
@@ -49,10 +62,10 @@ const CommunityMain: React.FC<{ onWriteButtonClick: () => void }> = ({
             잡담/수다
           </li>
           <li
-            onClick={() => setSelectedCategory("인턴후기")}
-            className={selectedCategory === "인턴후기" ? "selected" : ""}
+            onClick={() => setSelectedCategory("인턴리뷰")}
+            className={selectedCategory === "인턴리뷰" ? "selected" : ""}
           >
-            인턴후기
+            인턴리뷰
           </li>
           <li
             onClick={() => setSelectedCategory("대외활동")}
@@ -76,25 +89,33 @@ const CommunityMain: React.FC<{ onWriteButtonClick: () => void }> = ({
         <div
           key={index}
           className="community-content"
-          onClick={() => handleItemClick(item.contentId)}
+          onClick={() => handleItemClick(item.id)}
         >
           <div className="content-top">
-            <span className="category">{item.category}</span>
-            <p>{item.date}</p>
+            <span className="category">{item.category_name}</span>
+            <p>
+              {new Date(item.post_date).toLocaleString("ko-KR", {
+                dateStyle: "medium",
+                timeStyle: "short",
+              })}
+            </p>
           </div>
           <div className="content-middle">
             <h1>{item.title}</h1>
-            <p>{item.content}</p>
+            <p>{item.contents}</p>
           </div>
           <div className="content-bottom">
-            <p className="writer">{item.writer}</p>
+            <p className="writer">
+              {item.school_name} {item.major_name}{" "}
+              {String(item.admission_date).slice(-2)}학번
+            </p>
             <div className="content-numbers">
               <ChatIcon stroke="#66BB6A" />
-              <p className="color-chat">{item.chat}</p>
+              <p className="color-chat">{item.comment}</p>
               <LikeIcon stroke="#FF8181" />
               <p className="color-like">{item.like}</p>
               <ScrapIcon />
-              <p className="color-scrap">{item.scrap}</p>
+              <p className="color-scrap">{item.keep}</p>
             </div>
           </div>
         </div>

--- a/src/components/community/CommunityWrite.tsx
+++ b/src/components/community/CommunityWrite.tsx
@@ -17,9 +17,9 @@ const CommunityWrite: React.FC<{ onBackToMain: () => void }> = ({
         <div>
           <label>카테고리 선택</label>
           <select>
-            <option value="전공질문">전공질문</option>
+            <option value="전공질문">학과질문</option>
             <option value="잡담/수다">잡담/수다</option>
-            <option value="인턴후기">인턴후기</option>
+            <option value="인턴후기">인턴리뷰</option>
             <option value="대외활동">대외활동</option>
             <option value="우리학교는">우리학교는</option>
           </select>

--- a/src/components/home/HomeLogin.tsx
+++ b/src/components/home/HomeLogin.tsx
@@ -7,7 +7,7 @@ const HomeLogin = () => {
     navigate("/signup");
   };
   return (
-    <div className="login-container">
+    <div className="home-login-container">
       <div className="logo">
         <img src={require("../../assets/img/appLogo.png")} alt="logo" />
       </div>

--- a/src/components/signup/AgreeTerm.tsx
+++ b/src/components/signup/AgreeTerm.tsx
@@ -1,34 +1,88 @@
+import { useState, useEffect } from "react";
 import AgreeFirst from "../../data/AgreeFirst";
 import "../../styles/signup/AgreeTerm.scss";
 
 const AgreeTerm = () => {
+  const [allChecked, setAllChecked] = useState(false);
+  const [firstChecked, setFirstChecked] = useState(false);
+  const [secondChecked, setSecondChecked] = useState(false);
+  const [thirdChecked, setThirdChecked] = useState(false);
+
+  useEffect(() => {
+    if (allChecked) {
+      setFirstChecked(true);
+      setSecondChecked(true);
+      setThirdChecked(true);
+    } else {
+      setFirstChecked(false);
+      setSecondChecked(false);
+      setThirdChecked(false);
+    }
+  }, [allChecked]);
+
+  const handleAllChange = () => {
+    setAllChecked(!allChecked);
+  };
+
+  const handleFirstChange = () => {
+    setFirstChecked(!firstChecked);
+  };
+
+  const handleSecondChange = () => {
+    setSecondChecked(!secondChecked);
+  };
+
+  const handleThirdChange = () => {
+    setThirdChecked(!thirdChecked);
+  };
+
   return (
     <div>
       <h1>약관 동의</h1>
       <div className="agree-content">
         <div className="agree-all">
-          <input type="checkbox" id="all" />
+          <input
+            type="checkbox"
+            id="all"
+            checked={allChecked}
+            onChange={handleAllChange}
+          />
           <label htmlFor="all">
             이용약관, 개인정보 수집 및 이용, 개인정보 제 3자 제공 동의에 모두
             동의합니다.
           </label>
         </div>
         <div className="agree-first">
-          <input type="checkbox" id="first" />
+          <input
+            type="checkbox"
+            id="first"
+            checked={firstChecked}
+            onChange={handleFirstChange}
+          />
           <label htmlFor="first">
             이용약관 동의 <span>(필수)</span>
           </label>
           <AgreeFirst />
         </div>
         <div className="agree-second">
-          <input type="checkbox" id="second" />
+          <input
+            type="checkbox"
+            id="second"
+            checked={secondChecked}
+            onChange={handleSecondChange}
+          />
           <label htmlFor="second">
             개인정보 수집 및 이용 동의서 <span>(필수)</span>
           </label>
           <AgreeFirst />
         </div>
         <div className="agree-third">
-          <input type="checkbox" id="third" />
+          <input
+            type="checkbox"
+            id="third"
+            checked={thirdChecked}
+            onChange={handleThirdChange}
+          />
           <label htmlFor="third">
             개인정보 제 3자 정보 제공 동의{" "}
             <span className="choice">(선택)</span>

--- a/src/components/signup/Modal.tsx
+++ b/src/components/signup/Modal.tsx
@@ -1,0 +1,70 @@
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+const ModalPage = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ModalContent = styled.div`
+  background-color: #ffffff;
+  padding: 40px;
+  border-radius: 15px;
+`;
+
+const ResultText = styled.p`
+font-size: 1.5rem;
+font-weight; 700;
+text-align: center;
+`;
+
+const GoButton = styled.button`
+  width: 100%;
+  background-color: #1b1c3a;
+  border-radius: 5px;
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 1rem;
+  padding: 10px;
+  margin-top: 30px;
+`;
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  message: string;
+}
+
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, message }) => {
+  const navigate = useNavigate();
+  if (!isOpen) return null;
+
+  let buttonLabel;
+  let onClickHandler;
+
+  if (message === "회원가입 성공") {
+    buttonLabel = "로그인으로 이동";
+    onClickHandler = () => navigate("/login");
+  } else if (message === "회원가입 실패") {
+    buttonLabel = "회원가입 다시하기";
+    onClickHandler = onClose;
+  }
+
+  return (
+    <ModalPage>
+      <ModalContent>
+        <ResultText>{message}</ResultText>
+        <GoButton onClick={onClickHandler}>{buttonLabel}</GoButton>
+      </ModalContent>
+    </ModalPage>
+  );
+};
+
+export default Modal;

--- a/src/components/signup/SignUpBtn.tsx
+++ b/src/components/signup/SignUpBtn.tsx
@@ -1,5 +1,10 @@
 import "../../styles/signup/SignUpBtn.scss";
 import styled from "styled-components";
+import { useRecoilValue } from "recoil";
+import { studentDataState } from "../../data/recoilAtoms";
+import { postSignUpData } from "../../api/postData";
+import { useState } from "react";
+import Modal from "./Modal";
 
 const BtnContainer = styled.div`
   width: 100%;
@@ -11,12 +16,35 @@ const BtnContainer = styled.div`
 const SignUpBtn: React.FC<{ moveToBeforeStep: () => void }> = ({
   moveToBeforeStep,
 }) => {
+  const studentData = useRecoilValue(studentDataState);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+
+  const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    console.log(studentData);
+    const responseData = await postSignUpData("/users/register/", studentData);
+    if (responseData === "성공") {
+      setModalMessage("회원가입 성공");
+    } else {
+      setModalMessage("회원가입 실패");
+    }
+    setModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalOpen(false);
+  };
+
   return (
     <BtnContainer>
       <button className="before-button" onClick={moveToBeforeStep}>
         이전으로
       </button>
-      <button className="signup-button">회원가입</button>
+      <button className="signup-button" onClick={handleSubmit}>
+        회원가입
+      </button>
+      <Modal isOpen={modalOpen} onClose={closeModal} message={modalMessage} />
     </BtnContainer>
   );
 };

--- a/src/components/signup/StdCertify.tsx
+++ b/src/components/signup/StdCertify.tsx
@@ -2,18 +2,38 @@
 import { useState, ChangeEvent } from "react";
 import { ReactComponent as ImgIcon } from "../../assets/icon/img-search.svg";
 import "../../styles/signup/StdCertify.scss";
+import { postStudentCard } from "../../api/postStudentCard";
+import { useSetRecoilState } from "recoil";
+import { studentDataState } from "../../data/recoilAtoms";
 
 const StdCertify = () => {
   const [selectedImage, setSelectedImage] = useState<
     string | ArrayBuffer | null
   >(null);
+  const setStudentInfo = useSetRecoilState(studentDataState);
 
-  const handleImageUpload = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleImageUpload = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
       const reader = new FileReader();
-      reader.onload = () => {
+      reader.onload = async () => {
         setSelectedImage(reader.result);
+
+        const responseData = await postStudentCard(file);
+        console.log(responseData);
+        if (responseData.is_student_id_card) {
+          const { user_name, major_name, student_id, school_name } =
+            responseData;
+          setStudentInfo((prevData) => ({
+            ...prevData,
+            user_name,
+            major_name,
+            student_id,
+            school_name,
+          }));
+        } else {
+          alert("학생증 인식에 실패했습니다. 다시 업로드해주세요.");
+        }
       };
       reader.readAsDataURL(file);
     }
@@ -24,7 +44,7 @@ const StdCertify = () => {
       <h1>학생증 인증</h1>
       <div className="certify-content">
         <p>
-          카드 또는 모바일 학생증을 스캔하거나 사진으로 찍어 첨부해주세요.
+          학생증 카드를 수평을 맞춰서 학생증을 업로드 해주세요.
           <br />
           대학교, 이름, 학과, 학번이 필수적으로 기입되어 있어야 하며, 이를
           제외한 정보는

--- a/src/components/signup/StdInfo.tsx
+++ b/src/components/signup/StdInfo.tsx
@@ -1,22 +1,90 @@
+import { useState } from "react";
 import "../../styles/signup/StdInfo.scss";
+import { useRecoilState } from "recoil";
+import { studentDataState } from "../../data/recoilAtoms";
 
 const StdInfo = () => {
+  const [studentData, setStudentData] = useRecoilState(studentDataState);
+  const [passwordMatch, setPasswordMatch] = useState<boolean | null>(null);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+
+    setStudentData((prevData) => ({
+      ...prevData,
+      [name]: name === "admission_date" ? parseInt(value) : value,
+    }));
+
+    if (name === "home_password_check") {
+      const password = studentData["home_password"];
+      setPasswordMatch(password === value);
+    }
+  };
+
   return (
     <div>
       <h1>기본 정보</h1>
       <form className="signup-form">
         <label htmlFor="id">아이디</label>
-        <input type="text" id="id" />
+        <input
+          required
+          type="text"
+          id="id"
+          name="home_id"
+          onChange={handleChange}
+        />
         <label htmlFor="pw">비밀번호</label>
-        <input type="password" id="pw" />
-        <label htmlFor="pw-check">비밀번호 확인</label>
-        <input type="password" id="pw-check" />
+        <input
+          required
+          type="password"
+          id="pw"
+          autoComplete="new-password"
+          name="home_password"
+          onChange={handleChange}
+        />
+        <label htmlFor="pw-check">
+          비밀번호 확인
+          {passwordMatch !== null && (
+            <span className={passwordMatch ? "same" : "no-same"}>
+              {passwordMatch
+                ? "비밀번호가 일치합니다"
+                : "비밀번호가 일치하지 않습니다"}
+            </span>
+          )}
+        </label>
+        <input
+          required
+          type="password"
+          id="pw-check"
+          name="home_password_check"
+          autoComplete="new-password"
+          onChange={handleChange}
+        />
         <label htmlFor="email">이메일</label>
-        <input type="email" id="email" />
+        <input
+          required
+          type="email"
+          id="email"
+          name="email"
+          onChange={handleChange}
+        />
         <label htmlFor="phone">전화번호</label>
-        <input type="tel" id="phone" />
+        <input
+          required
+          type="tel"
+          id="phone"
+          name="phonenumber"
+          onChange={handleChange}
+        />
         <label htmlFor="year">입학년도</label>
-        <select id="year">
+        <select
+          required
+          id="year"
+          name="admission_date"
+          onChange={handleChange}
+        >
           <option value="">--연도를 선택하세요--</option>
           {Array.from({ length: 30 }, (_, index) => {
             const year = new Date().getFullYear() - index;

--- a/src/components/study/StudyDetail.tsx
+++ b/src/components/study/StudyDetail.tsx
@@ -1,20 +1,31 @@
-import { useParams } from "react-router-dom";
-import data, { StudyData } from "../../data/StudyData";
+// import data, { StudyData } from "../../data/StudyData";
 import { ReactComponent as UserIcon } from "../../assets/icon/user.svg";
 import { ReactComponent as SendIcon } from "../../assets/icon/send.svg";
 import { ReactComponent as ReplyIcon } from "../../assets/icon/reply.svg";
 import "../../styles/study/StudyDetail.scss";
+import { useParams } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { StudyData } from "../../types/Types";
+import { fetchData } from "../../api/fetchData";
 
 const StudyDetail = () => {
   const { studyId } = useParams();
   const parsedStudyId = studyId ? parseInt(studyId) : undefined;
-  const selectedData = data.find((item) => item.studyId === parsedStudyId);
-  const hashTags = selectedData?.hashtags;
+
+  const [selectedData, setSelectedData] = useState<StudyData>();
+  useEffect(() => {
+    const fetchStudyData = async () => {
+      const data = await fetchData(`/studys/posts/${parsedStudyId}/`);
+      setSelectedData(data);
+    };
+
+    fetchStudyData();
+  }, [parsedStudyId]);
 
   if (!selectedData) {
     return <div>해당 컨텐츠를 찾을 수 없습니다.</div>;
   }
-  const commentData = selectedData?.comments || [];
+  // const commentData = selectedData?.comments || [];
 
   return (
     <div className="study-container">
@@ -23,21 +34,29 @@ const StudyDetail = () => {
           <div>
             <h1>{selectedData.title}</h1>
             <p>
-              {selectedData.school}
-              <span> ・ {selectedData.date}</span>
+              {selectedData.school_name} {selectedData.major_name}{" "}
+              {String(selectedData.admission_date).slice(-2)}학번 ·{" "}
+              <span>
+                {" "}
+                ・{" "}
+                {new Date(selectedData.post_date).toLocaleString("ko-KR", {
+                  dateStyle: "medium",
+                  timeStyle: "short",
+                })}
+              </span>
             </p>
           </div>
           <div
             className={`${
-              selectedData.recruiting === "모집중" ? "recruiting" : "completed"
+              selectedData.is_recruited === false ? "recruiting" : "recruited"
             }`}
           >
-            {selectedData.recruiting}
+            {selectedData.is_recruited === false ? "모집중" : "모집완료"}
           </div>
         </div>
-        <div className="middle">{selectedData.description}</div>
+        <div className="middle">{selectedData.contents}</div>
         <div className="bottom">
-          {hashTags?.map((item, index) => (
+          {selectedData.hashtags.map((item, index) => (
             <span key={index} className="category">
               #{item}
             </span>
@@ -53,7 +72,7 @@ const StudyDetail = () => {
             <SendIcon stroke="#1b1c3a" />
           </div>
         </form>
-        {commentData?.map((comment, index) => {
+        {/* {commentData?.map((comment, index) => {
           return (
             <div key={index} className="comment-container">
               <div className="info">
@@ -72,7 +91,7 @@ const StudyDetail = () => {
               </div>
             </div>
           );
-        })}
+        })} */}
       </div>
     </div>
   );

--- a/src/components/study/StudyList.tsx
+++ b/src/components/study/StudyList.tsx
@@ -1,20 +1,34 @@
 import { ReactComponent as PencilIcon } from "../../assets/icon/pencil.svg";
 import { ReactComponent as ChatIcon } from "../../assets/icon/chat-color.svg";
 import { ReactComponent as LikeIcon } from "../../assets/icon/like-color.svg";
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import "../../styles/study/StudyList.scss";
-import data, { StudyData } from "../../data/StudyData";
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+// import data, { StudyData } from "../../data/StudyData";
+import { fetchData } from "../../api/fetchData";
+import { StudyData } from "../../types/Types";
 
 interface StudySearchProps {
   selectedFilter: string;
 }
 
 const StudyList: React.FC<StudySearchProps> = ({ selectedFilter }) => {
-  const filteredStudyData: StudyData[] = data.filter(
+  const [studyData, setStudyData] = useState<StudyData[]>([]);
+
+  useEffect(() => {
+    const fetchStudyData = async () => {
+      const data = await fetchData("/studys/posts/");
+      setStudyData(data);
+    };
+
+    fetchStudyData();
+  }, []);
+
+  const filteredStudyData: StudyData[] = studyData.filter(
     (item) =>
       selectedFilter === "all" ||
-      item.recruiting.toLowerCase() === selectedFilter
+      (selectedFilter === "recruiting" && item.is_recruited === false) ||
+      (selectedFilter === "recruited" && item.is_recruited === true)
   );
 
   const [selectedFilter2, setSelectedFilter2] = useState("recent");
@@ -64,19 +78,19 @@ const StudyList: React.FC<StudySearchProps> = ({ selectedFilter }) => {
         <div
           key={index}
           className="study-list"
-          onClick={() => handleItemClick(item.studyId)}
+          onClick={() => handleItemClick(item.id)}
         >
           <h1>
             <span
               className={`${
-                item.recruiting === "모집중" ? "recruiting" : "completed"
+                item.is_recruited === false ? "recruiting" : "recruited"
               }`}
             >
-              {item.recruiting}
+              {item.is_recruited === false ? "모집중" : "모집완료"}
             </span>
             {item.title}
           </h1>
-          <p>{item.description}</p>
+          <p>{item.contents}</p>
           {item.hashtags.map((hashtag, index) => (
             <span className="category" key={index}>
               # {hashtag}
@@ -84,12 +98,20 @@ const StudyList: React.FC<StudySearchProps> = ({ selectedFilter }) => {
           ))}
           <footer>
             <div className="bottom-left">
-              <p>{item.school} · </p>
-              <p>{item.date}</p>
+              <p>
+                {item.school_name} {item.major_name}{" "}
+                {String(item.admission_date).slice(-2)}학번 ·{" "}
+              </p>
+              <p>
+                {new Date(item.post_date).toLocaleString("ko-KR", {
+                  dateStyle: "medium",
+                  timeStyle: "short",
+                })}
+              </p>
             </div>
             <div className="bottom-right">
               <ChatIcon stroke="#1B1C3A" />
-              <p>{item.chat}</p>
+              <p>{item.comment}</p>
               <LikeIcon stroke="#1B1C3A" />
               <p>{item.like}</p>
             </div>

--- a/src/components/study/StudySearch.tsx
+++ b/src/components/study/StudySearch.tsx
@@ -11,7 +11,6 @@ const StudySearch: React.FC<StudySearchProps> = ({
   selectedFilter,
   onFilterChange,
 }) => {
-  // const [selectedFilter, setSelectedFilter] = useState("all");
   const [searchText, setSearchText] = useState<string>("");
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
 
@@ -51,14 +50,14 @@ const StudySearch: React.FC<StudySearchProps> = ({
             전체보기
           </li>
           <li
-            className={selectedFilter === "모집중" ? "selected" : ""}
-            onClick={() => handleFilterChange("모집중")}
+            className={selectedFilter === "recruiting" ? "selected" : ""}
+            onClick={() => handleFilterChange("recruiting")}
           >
             모집중
           </li>
           <li
-            className={selectedFilter === "모집완료" ? "selected" : ""}
-            onClick={() => handleFilterChange("모집완료")}
+            className={selectedFilter === "recruited" ? "selected" : ""}
+            onClick={() => handleFilterChange("recruited")}
           >
             모집완료
           </li>

--- a/src/components/study/StudyWriter.tsx
+++ b/src/components/study/StudyWriter.tsx
@@ -1,14 +1,27 @@
 import { ReactComponent as PencilIcon } from "../../assets/icon/pencil.svg";
 import { ReactComponent as UserIcon } from "../../assets/icon/user.svg";
-import { useParams, useNavigate } from "react-router-dom";
-import data, { StudyData } from "../../data/StudyData";
 import "../../styles/study/StudyWriter.scss";
+import { useParams, useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { StudyData } from "../../types/Types";
+import { fetchData } from "../../api/fetchData";
+// import data, { StudyData } from "../../data/StudyData";
 
 const StudyWriter = () => {
   const navigate = useNavigate();
   const { studyId } = useParams();
   const parsedStudyId = studyId ? parseInt(studyId) : undefined;
-  const selectedData = data.find((item) => item.studyId === parsedStudyId);
+
+  const [selectedData, setSelectedData] = useState<StudyData>();
+  useEffect(() => {
+    const fetchStudyData = async () => {
+      const data = await fetchData(`/studys/posts/${parsedStudyId}/`);
+      setSelectedData(data);
+    };
+
+    fetchStudyData();
+  }, [parsedStudyId]);
+
   if (!selectedData) {
     return <div>해당 컨텐츠를 찾을 수 없습니다.</div>;
   }
@@ -33,10 +46,16 @@ const StudyWriter = () => {
       <div className="writer">
         <div className="info-top">
           <div className="info">
-            <p>{selectedData.school}</p>
+            <p>
+              {selectedData.school_name} {selectedData.major_name}
+              <br />
+              {String(selectedData.admission_date).slice(-2)}학번
+            </p>
             <ul>
-              <li>작성한 글수 {selectedData.write}</li>
-              <li>관심분야 {selectedData.interest}</li>
+              <li>작성한 글수 10</li>
+              <li>관심분야 Front-End, DevOps</li>
+              {/* <li>작성한 글수 {selectedData.write}</li> */}
+              {/* <li>관심분야 {selectedData.interest}</li> */}
             </ul>
           </div>
           <UserIcon width="64" height="64" />

--- a/src/data/recoilAtoms.tsx
+++ b/src/data/recoilAtoms.tsx
@@ -1,0 +1,19 @@
+import { atom } from "recoil";
+import { StudentData } from "../types/Types";
+
+export const studentDataState = atom<StudentData>({
+  key: "studentDataState", // 상태를 식별하기 위한 고유한 키입니다.
+  default: {
+    user_name: "장현정",
+    school_name: "단국대학교",
+    major_name: "경영학과",
+    student_id: 32203928,
+    major_id: 0,
+    home_id: "",
+    home_password: "",
+    home_password_check: "",
+    email: "",
+    phonenumber: "",
+    admission_date: 0,
+  },
+});

--- a/src/pages/home/HomeApp.tsx
+++ b/src/pages/home/HomeApp.tsx
@@ -11,10 +11,11 @@ const HomeContainer = styled.div`
 
 const HomeLeft = styled.div`
   width: 40%;
-  height: 100vh;
+  min-height: 100vh;
   max-width: 400px;
   min-width: 350px;
   background: #1b1c3a;
+  overflow: auto;
 `;
 
 const HomeRight = styled.div`

--- a/src/styles/home/HomeLogin.scss
+++ b/src/styles/home/HomeLogin.scss
@@ -1,11 +1,11 @@
-.login-container {
+.home-login-container {
   width: 80%;
-  height: 50vh;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  padding: 40px 0;
 
   .login {
     width: 300px;

--- a/src/styles/signup/SchoolInfo.scss
+++ b/src/styles/signup/SchoolInfo.scss
@@ -34,13 +34,16 @@
 }
 
 .match {
-  display: flex;
-  justify-content: space-between;
-
   div {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 10px;
+
+    span {
+      color: #777;
+      font-size: 0.8rem;
+    }
   }
 }
 

--- a/src/styles/signup/StdInfo.scss
+++ b/src/styles/signup/StdInfo.scss
@@ -20,4 +20,17 @@
     background: #f3f3f3;
     margin-bottom: 20px;
   }
+
+  span {
+    font-size: 0.7rem;
+    margin-left: 15px;
+  }
+
+  .same {
+    color: #49c723;
+  }
+
+  .no-same {
+    color: #f74646;
+  }
 }

--- a/src/styles/study/StudyList.scss
+++ b/src/styles/study/StudyList.scss
@@ -52,7 +52,7 @@
     padding: 5px 15px;
   }
 
-  .completed {
+  .recruited {
     @extend .recruiting;
     background: #cccccc;
   }

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -1,0 +1,43 @@
+export interface StudentData {
+  user_name: string;
+  school_name: string;
+  major_name: string;
+  student_id: number;
+  major_id: number;
+  home_id: string;
+  home_password: string;
+  home_password_check: string;
+  email: string;
+  phonenumber: string;
+  admission_date: number;
+}
+
+export interface CommunityData {
+  id: number;
+  user_id: number;
+  category_name: string;
+  title: string;
+  contents: string;
+  post_date: string;
+  comment: number;
+  like: number;
+  keep: number;
+  school_name: string;
+  major_name: string;
+  admission_date: number;
+}
+
+export interface StudyData {
+  id: number;
+  user_id: number;
+  title: string;
+  contents: string;
+  hashtags: [];
+  is_recruited: boolean;
+  post_date: string;
+  comment: number;
+  like: number;
+  school_name: string;
+  major_name: string;
+  admission_date: number;
+}


### PR DESCRIPTION
1. 회원가입 페이지 api 연결
  - api 모듈 분리
  - 회원가입 데이터 저장을 위한 recoil 생성
  - 회원가입 데이터 타입 파일 생성 및 구현
  - postData 호출로 회원가입 폼 post 전달
  - postStudentCard호출로 학생증 인증 post 연결
  - 개인정보 동의 전체선택 이벤트 적용
  - 회원가입 결과를 보여주기 위한 모달창 구현(성공하면 로그인 화면 이동, 실패하면 onClose되도록)

2. 커뮤니티 게시판 get api 연결
  - 데이터 추출을 위해 get 호출이 구현된 fetchData 메소드 추가
  - id를 이용해 상세조회 이동
  - Type.ts파일에 커뮤니티 데이터에 대한 타입 지정
 
3. 스터디 게시판 get api 연결
  - 모집중, 모집완료 is_recruited로 필터링 변경
  - fetchData를 이용해 get으로 api 연결
  - id를 이용해 상세조회 이동
  - 글 작성자 학교, 학과, 학번 정도 추출
  - Type.ts 파일에 스터디 데이터에 대한 타입 지정

4. Home에서 로그인 화면 스타일링 화면 사이즈에 따른 오류로 인해 디자인 수정