### PR TITLE
[FE-DEV, UPDATE] 중고거래, 커뮤니티 글 검색, 스터디 글 검색 api 연결

### DIFF
--- a/src/api/postData.tsx
+++ b/src/api/postData.tsx
@@ -20,7 +20,6 @@ export const postTokenData = async (endpoint: string, formData: FormData) => {
   const userId = auth ? auth.user_id : null;
 
   formData.append("user_id", userId);
-  const imgfile = formData.get("imgfile");
 
   if (!accessToken) {
     throw new Error("Access token is not available");
@@ -33,7 +32,6 @@ export const postTokenData = async (endpoint: string, formData: FormData) => {
       },
     });
 
-    // console.log("서버로부터의 응답:", response.data);
     return response.data;
   } catch (error) {
     console.log(error);
@@ -43,12 +41,8 @@ export const postTokenData = async (endpoint: string, formData: FormData) => {
 export const postSignUpData = async (endpoint: string, data: any) => {
   try {
     const response = await axios.post(`${API_BASE_URL}${endpoint}`, data);
-    console.log("서버로부터의 응답:", response.data);
     return "성공";
-    // return response.data;
   } catch (error: any) {
-    // console.log(error);
-    // console.log(error.request.response);
     return "실패";
   }
 };

--- a/src/components/community/CommunityMain.tsx
+++ b/src/components/community/CommunityMain.tsx
@@ -14,22 +14,37 @@ const CommunityMain: React.FC<{ onWriteButtonClick: () => void }> = ({
 }) => {
   const [selectedCategory, setSelectedCategory] = useState("전체보기");
   const [communityData, setCommunityData] = useState<CommunityData[]>([]);
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [isSearching, setIsSearching] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchCommunityData = async () => {
-      const data = await fetchData("/boards/posts/");
+      let endpoint = "/boards/posts/";
+      if (isSearching && searchKeyword) {
+        endpoint = `/boards/posts/search/?keyword=${searchKeyword}`;
+      }
+      const data = await fetchData(endpoint);
       setCommunityData(data);
     };
 
     fetchCommunityData();
-  }, []);
+  }, [selectedCategory, searchKeyword, isSearching]);
 
   const filteredData: CommunityData[] = communityData.filter(
     (item) =>
       selectedCategory === "전체보기" || item.category_name === selectedCategory
   );
 
-  const navigate = useNavigate();
+  const handleSearchInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setSearchKeyword(event.target.value);
+  };
+
+  const handleSearchClick = () => {
+    setIsSearching(true);
+  };
 
   const handleItemClick = (contentId: number) => {
     navigate(`/community/${contentId}`);
@@ -38,8 +53,13 @@ const CommunityMain: React.FC<{ onWriteButtonClick: () => void }> = ({
   return (
     <div className="community-container">
       <div className="search">
-        <input type="text" placeholder="검색어를 입력해주세요" />
-        <SearchIcon />
+        <input
+          type="text"
+          placeholder="검색어를 입력해주세요"
+          value={searchKeyword}
+          onChange={handleSearchInputChange}
+        />
+        <SearchIcon onClick={handleSearchClick} />
       </div>
       <div className="community-filtering">
         <ul>

--- a/src/components/study/StudyDetail.tsx
+++ b/src/components/study/StudyDetail.tsx
@@ -55,7 +55,7 @@ const StudyDetail = () => {
           </div>
         </div>
         <div className="middle">{selectedData.contents}</div>
-        <div className="bottom">
+        <div className="study-bottom">
           {selectedData.hashtags.map((item, index) => (
             <span key={index} className="category">
               #{item}

--- a/src/components/study/StudyList.tsx
+++ b/src/components/study/StudyList.tsx
@@ -10,19 +10,27 @@ import { StudyData } from "../../types/Types";
 
 interface StudySearchProps {
   selectedFilter: string;
+  searchText: string;
 }
 
-const StudyList: React.FC<StudySearchProps> = ({ selectedFilter }) => {
+const StudyList: React.FC<StudySearchProps> = ({
+  selectedFilter,
+  searchText,
+}) => {
   const [studyData, setStudyData] = useState<StudyData[]>([]);
 
   useEffect(() => {
     const fetchStudyData = async () => {
-      const data = await fetchData("/studys/posts/");
+      let endpoint = "/studys/posts/";
+      if (searchText.trim() !== "") {
+        endpoint = `/studys/posts/search/?hashtag=${searchText}&keyword=${searchText}`;
+      }
+      const data = await fetchData(endpoint);
       setStudyData(data);
     };
 
     fetchStudyData();
-  }, []);
+  }, [searchText]);
 
   const filteredStudyData: StudyData[] = studyData.filter(
     (item) =>

--- a/src/components/study/StudySearch.tsx
+++ b/src/components/study/StudySearch.tsx
@@ -4,12 +4,15 @@ import "../../styles/study/StudySearch.scss";
 
 interface StudySearchProps {
   selectedFilter: string;
+  searchText: string;
   onFilterChange: (filter: string) => void;
+  onSearchChange: (filter: string) => void;
 }
 
 const StudySearch: React.FC<StudySearchProps> = ({
   selectedFilter,
   onFilterChange,
+  onSearchChange,
 }) => {
   const [searchText, setSearchText] = useState<string>("");
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
@@ -21,6 +24,7 @@ const StudySearch: React.FC<StudySearchProps> = ({
   const handleSearch = () => {
     if (searchText.trim() !== "") {
       setRecentSearches([searchText, ...recentSearches]);
+      onSearchChange(searchText);
     }
     setSearchText("");
   };

--- a/src/components/trade/BookSearch.tsx
+++ b/src/components/trade/BookSearch.tsx
@@ -2,8 +2,9 @@ import { ReactComponent as SearchIcon } from "../../assets/icon/search.svg";
 import { ReactComponent as PriceIcon } from "../../assets/icon/price.svg";
 import { ReactComponent as BookIcon } from "../../assets/icon/book-search.svg";
 import "../../styles/trade/TradeWrite.scss";
-// import data, { SearchData } from "../../data/SearchData";
 import { useState, useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { bookState } from "../../data/recoilAtoms";
 import { fetchData } from "../../api/fetchData";
 import { BookSearchData } from "../../types/Types";
 
@@ -11,6 +12,7 @@ const BookSearch: React.FC = () => {
   const [selectedBook, setSelectedBook] = useState<BookSearchData | null>(null);
   const [searchBook, setSearchBook] = useState<BookSearchData[]>([]);
   const [searchWord, setSearchWord] = useState<string>("");
+  const [bookData, setBookData] = useRecoilState(bookState);
 
   const fetchSearchData = async (word: string) => {
     const decodedWord = decodeURIComponent(word);
@@ -40,6 +42,17 @@ const BookSearch: React.FC = () => {
   ) => {
     event.preventDefault();
     setSelectedBook(book);
+    setBookData({
+      title: book.title,
+      author: book.author,
+      seller: 0,
+      publisher: book.publisher,
+      origin_imgfile: book.image,
+      price: "",
+      imgfile: null,
+      description: "",
+      damage_level: "",
+    });
   };
 
   return (

--- a/src/components/trade/TradeAll.tsx
+++ b/src/components/trade/TradeAll.tsx
@@ -1,21 +1,32 @@
 import { ReactComponent as PriceIcon } from "../../assets/icon/price.svg";
 import { ReactComponent as SalerIcon } from "../../assets/icon/saler.svg";
 import { ReactComponent as ChatIcon } from "../../assets/icon/chat-color.svg";
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import "../../styles/trade/TradeAll.scss";
-import data, { TradeData } from "../../data/TradeData";
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { fetchData } from "../../api/fetchData";
+import { BookData } from "../../types/Types";
 
 const TradeAll = () => {
   const [selectedFilter, setSelectedFilter] = useState("all");
+  const [bookData, setBookData] = useState<BookData[]>([]);
+
+  useEffect(() => {
+    const fetchBookData = async () => {
+      const data = await fetchData("/usedbooktrades/posts/");
+      setBookData(data);
+    };
+    fetchBookData();
+  }, []);
+
   const handleFilterChange = (filter: any) => {
     setSelectedFilter(filter);
   };
   const bookDataFiltered =
     selectedFilter === "all"
-      ? data
-      : data.filter((item) =>
-          selectedFilter === "selling" ? item.sale : !item.sale
+      ? bookData
+      : bookData.filter((item) =>
+          selectedFilter === "selling" ? !item.is_sold : item.is_sold
         );
 
   const navigate = useNavigate();
@@ -52,30 +63,38 @@ const TradeAll = () => {
         <div
           key={index}
           className="book-content"
-          onClick={() => goTradeItemClick(item.tradeId)}
+          onClick={() => goTradeItemClick(item.id)}
         >
           <div className="img">
-            <img src={item.img} alt="img" />
+            <img src={item.origin_imgfile} alt="img" />
           </div>
           <div className="description">
-            <span className={item.sale ? "selling" : "sold-out"}>
-              {item.sale ? "판매중" : "판매완료"}
+            <span className={item.is_sold ? "sold-out" : "selling"}>
+              {item.is_sold ? "판매완료" : "판매중"}
             </span>
             <h1>{item.title}</h1>
             <p className="author">{item.author}</p>
-            <p className="publish">{item.publish}</p>
+            <p className="publish">{item.publisher}</p>
             <div>
               <PriceIcon />
               <p className="price">{item.price.toLocaleString()}원</p>
             </div>
             <div>
               <SalerIcon />
-              <p className="saler">{item.saler}</p>
+              <p className="saler">
+                {item.school_name} {item.major_name}{" "}
+                {String(item.admission_date).slice(-2)}학번
+              </p>
             </div>
             <footer>
-              <p>{item.posting}</p>
+              <p>
+                {new Date(item.post_date).toLocaleString("ko-KR", {
+                  dateStyle: "medium",
+                  timeStyle: "short",
+                })}
+              </p>
               <ChatIcon stroke="#9B9B9B" />
-              <p>{item.chat}</p>
+              <p>{item.comment}</p>
             </footer>
           </div>
         </div>

--- a/src/components/trade/TradeDetail.tsx
+++ b/src/components/trade/TradeDetail.tsx
@@ -5,38 +5,49 @@ import { ReactComponent as ChatIcon } from "../../assets/icon/chat-color.svg";
 import { ReactComponent as UserIcon } from "../../assets/icon/user.svg";
 import { ReactComponent as SendIcon } from "../../assets/icon/send.svg";
 import { ReactComponent as ReplyIcon } from "../../assets/icon/reply.svg";
-import { useParams } from "react-router-dom";
-import data, { TradeData } from "../../data/TradeData";
 import "../../styles/study/StudyDetail.scss";
 import "../../styles/trade/TradeDetail.scss";
+import { useParams } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { BookData } from "../../types/Types";
+import { fetchData } from "../../api/fetchData";
 
 const TradeDetail = () => {
   const { tradeId } = useParams();
-  const parsedStudyId = tradeId ? parseInt(tradeId) : undefined;
-  const selectedData = data.find((item) => item.tradeId === parsedStudyId);
+  const parsedTradeId = tradeId ? parseInt(tradeId) : undefined;
+  const [selectedData, setSelectedData] = useState<BookData>();
+
+  useEffect(() => {
+    const fetchCommunityData = async () => {
+      const data = await fetchData(`/usedbooktrades/posts/${parsedTradeId}/`);
+      setSelectedData(data);
+    };
+
+    fetchCommunityData();
+  }, [parsedTradeId]);
 
   if (!selectedData) {
     return <div>해당 컨텐츠를 찾을 수 없습니다.</div>;
   }
-  const commentData = selectedData?.comments || [];
+  // const commentData = selectedData?.comments || [];
 
   return (
     <div className="trade-container">
       <div className="trade-detail-container">
         <div className="top">
-          <span className={selectedData.sale ? "selling" : "sold-out"}>
-            {selectedData.sale ? "판매중" : "판매완료"}
+          <span className={selectedData.is_sold ? "sold-out" : "selling"}>
+            {selectedData.is_sold ? "판매완료" : "판매중"}
           </span>
         </div>
-        <div className="bottom">
+        <div className="middle">
           <div className="img">
-            <img src={selectedData.img} alt="img" />
+            <img src={selectedData.origin_imgfile} alt="img" />
           </div>
           <div className="description">
             <h1>{selectedData.title}</h1>
             <div>
               <p>{selectedData.author}</p>
-              <p>{selectedData.publish}</p>
+              <p>{selectedData.publisher}</p>
             </div>
             <ul>
               <li>
@@ -45,7 +56,8 @@ const TradeDetail = () => {
               </li>
               <li>
                 <SalerIcon />
-                {selectedData.saler}
+                {selectedData.school_name} {selectedData.major_name}{" "}
+                {String(selectedData.admission_date).slice(-2)}학번
               </li>
               <li>
                 <DamageIcon />
@@ -53,11 +65,24 @@ const TradeDetail = () => {
               </li>
             </ul>
             <p className="info">{selectedData.description}</p>
-            <div className="posting">
-              <p>{selectedData.posting}</p>
-              <ChatIcon stroke="#9B9B9B" />
-              <p>{selectedData.chat}</p>
+          </div>
+        </div>
+        <div className="bottom">
+          {selectedData.imgfile !== null && (
+            <div className="img-zip">
+              <h1>책 상태 사진</h1>
+              <img src={selectedData.imgfile} alt="" />
             </div>
+          )}
+          <div className="posting">
+            <p>
+              {new Date(selectedData.post_date).toLocaleString("ko-KR", {
+                dateStyle: "medium",
+                timeStyle: "short",
+              })}
+            </p>
+            <ChatIcon stroke="#9B9B9B" />
+            <p>{selectedData.comment}</p>
           </div>
         </div>
       </div>
@@ -70,7 +95,7 @@ const TradeDetail = () => {
             <SendIcon stroke="#1b1c3a" />
           </div>
         </form>
-        {commentData?.map((comment, index) => {
+        {/* {commentData?.map((comment, index) => {
           return (
             <div key={index} className="comment-container">
               <div className="info">
@@ -89,7 +114,7 @@ const TradeDetail = () => {
               </div>
             </div>
           );
-        })}
+        })} */}
       </div>
     </div>
   );

--- a/src/components/trade/TradeSaler.tsx
+++ b/src/components/trade/TradeSaler.tsx
@@ -1,10 +1,29 @@
 import { ReactComponent as UserIcon } from "../../assets/icon/user.svg";
 import { ReactComponent as PencilIcon } from "../../assets/icon/pencil.svg";
-import { useNavigate } from "react-router-dom";
 import "../../styles/trade/TradeSaler.scss";
+import { useParams, useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { fetchData } from "../../api/fetchData";
+import { BookData } from "../../types/Types";
 
 const TradeSaler = () => {
   const navigate = useNavigate();
+  const { tradeId } = useParams();
+  const parsedTradeId = tradeId ? parseInt(tradeId) : undefined;
+
+  const [selectedData, setSelectedData] = useState<BookData>();
+  useEffect(() => {
+    const fetchStudyData = async () => {
+      const data = await fetchData(`/usedbooktrades/posts/${parsedTradeId}/`);
+      setSelectedData(data);
+    };
+
+    fetchStudyData();
+  }, [parsedTradeId]);
+
+  if (!selectedData) {
+    return <div>해당 컨텐츠를 찾을 수 없습니다.</div>;
+  }
   const goBack = () => {
     navigate("/trade");
   };
@@ -17,7 +36,10 @@ const TradeSaler = () => {
       <div className="saler-container">
         <UserIcon width="96" height="96" />
         <div className="field-container">
-          <h2>단국대학교 소프트웨어학과 20학번</h2>
+          <h2>
+            {selectedData.school_name} {selectedData.major_name}{" "}
+            {String(selectedData.admission_date).slice(-2)}학번
+          </h2>
           <div className="field-info">
             <h3>작성한 글수</h3>
             <p>10</p>

--- a/src/components/trade/TradeToday.tsx
+++ b/src/components/trade/TradeToday.tsx
@@ -1,12 +1,22 @@
 import { ReactComponent as PriceIcon } from "../../assets/icon/price.svg";
 import { ReactComponent as SalerIcon } from "../../assets/icon/saler.svg";
 import { ReactComponent as ChatIcon } from "../../assets/icon/chat-color.svg";
-import { useNavigate } from "react-router-dom";
 import "../../styles/trade/TradeToday.scss";
-import data, { TradeData } from "../../data/TradeData";
+import { useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { fetchData } from "../../api/fetchData";
+import { BookData } from "../../types/Types";
 
 const TradeToday = () => {
   const navigate = useNavigate();
+  const [bookData, setBookData] = useState<BookData[]>([]);
+  useEffect(() => {
+    const fetchBookData = async () => {
+      const data = await fetchData("/usedbooktrades/posts/");
+      setBookData(data);
+    };
+    fetchBookData();
+  }, []);
   const goTradeItemClick = (tradeId: number) => {
     navigate(`/trade/${tradeId}`);
   };
@@ -15,34 +25,43 @@ const TradeToday = () => {
     <div className="trade-today-container">
       <h1>📚 오늘 등록된 교재</h1>
       <div className="book-container">
-        {data.map((item, index) => (
+        {bookData.map((item, index) => (
           <div
             key={index}
             className="book-content"
-            onClick={() => goTradeItemClick(item.tradeId)}
+            onClick={() => goTradeItemClick(item.id)}
           >
             <div className="img">
-              <img src={item.img} alt="img" />
+              <img src={item.origin_imgfile} alt="img" />
             </div>
             <div className="description">
-              <span className={item.sale ? "selling" : "sold-out"}>
-                {item.sale ? "판매중" : "판매완료"}
+              <span className={item.is_sold ? "sold-out" : "selling"}>
+                {item.is_sold ? "판매완료" : "판매중"}
               </span>
               <h1>{item.title}</h1>
               <p className="author">{item.author}</p>
-              <p className="publish">{item.publish}</p>
+              <p className="publish">{item.publisher}</p>
               <div>
                 <PriceIcon />
                 <p className="price">{item.price.toLocaleString()}원</p>
               </div>
               <div>
                 <SalerIcon />
-                <p className="saler">{item.saler}</p>
+                <p className="saler">
+                  {item.school_name} {item.major_name}{" "}
+                  {String(item.admission_date).slice(-2)}학번
+                </p>
               </div>
               <footer>
-                <p>{item.posting}</p>
+                <p>
+                  {" "}
+                  {new Date(item.post_date).toLocaleString("ko-KR", {
+                    dateStyle: "medium",
+                    timeStyle: "short",
+                  })}
+                </p>
                 <ChatIcon stroke="#9B9B9B" />
-                <p>{item.chat}</p>
+                <p>{item.comment}</p>
               </footer>
             </div>
           </div>

--- a/src/data/recoilAtoms.tsx
+++ b/src/data/recoilAtoms.tsx
@@ -1,13 +1,13 @@
 import { atom } from "recoil";
-import { StudentData } from "../types/Types";
+import { StudentData, BookWriteData } from "../types/Types";
 
 export const studentDataState = atom<StudentData>({
   key: "studentDataState", // 상태를 식별하기 위한 고유한 키입니다.
   default: {
-    user_name: "장장장",
-    school_name: "단국대학교",
-    major_name: "소프트웨어학과",
-    student_id: 32203928,
+    user_name: "",
+    school_name: "",
+    major_name: "",
+    student_id: 0,
     major_id: 0,
     home_id: "",
     home_password: "",
@@ -29,5 +29,20 @@ export const loginState = atom({
     major_name: null as string | null,
     admission_date: null as number | null,
     user_id: null as number | null,
+  },
+});
+
+export const bookState = atom<BookWriteData>({
+  key: "bookDataState",
+  default: {
+    title: "",
+    author: "",
+    seller: 0,
+    publisher: "",
+    origin_imgfile: "",
+    price: "",
+    imgfile: null,
+    description: "",
+    damage_level: "",
   },
 });

--- a/src/pages/study/StudyApp.tsx
+++ b/src/pages/study/StudyApp.tsx
@@ -21,6 +21,7 @@ const StudyContent = styled.div`
 
 const StudyApp = () => {
   const [selectedFilter, setSelectedFilter] = useState("all");
+  const [searchText, setSearchText] = useState("");
   return (
     <StudyContainer>
       <Routes>
@@ -31,9 +32,14 @@ const StudyApp = () => {
               <StudyContent>
                 <StudySearch
                   selectedFilter={selectedFilter}
+                  searchText={searchText}
+                  onSearchChange={setSearchText}
                   onFilterChange={setSelectedFilter}
                 />
-                <StudyList selectedFilter={selectedFilter} />
+                <StudyList
+                  selectedFilter={selectedFilter}
+                  searchText={searchText}
+                />
               </StudyContent>
               <PopularStudy />
             </>

--- a/src/styles/study/StudyDetail.scss
+++ b/src/styles/study/StudyDetail.scss
@@ -44,6 +44,10 @@
       margin: 40px 0;
       font-size: 0.9rem;
     }
+
+    .study-bottom {
+      display: flex;
+    }
   }
 
   .study-detail-comment,

--- a/src/styles/trade/TradeDetail.scss
+++ b/src/styles/trade/TradeDetail.scss
@@ -22,7 +22,7 @@
     }
   }
 
-  .bottom {
+  .middle {
     display: flex;
     gap: 20px;
     .img {
@@ -64,15 +64,35 @@
         font-weight: 500;
         font-size: 0.9rem;
       }
-      .posting {
-        display: flex;
-        justify-content: flex-end;
-        gap: 10px;
-        p {
-          &:nth-child(3) {
-            margin-left: -5px;
-          }
-        }
+    }
+  }
+}
+.bottom {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin-top: 40px;
+
+  .img-zip {
+    h1 {
+      font-size: 1rem;
+      margin-bottom: 5px;
+    }
+    img {
+      width: 200px;
+      height: 200px;
+      border-radius: 5px;
+    }
+  }
+  .posting {
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    gap: 10px;
+    p {
+      &:nth-child(3) {
+        margin-left: -5px;
       }
     }
   }

--- a/src/styles/trade/TradeToday.scss
+++ b/src/styles/trade/TradeToday.scss
@@ -18,7 +18,7 @@
 }
 .book-content {
   width: 60%;
-  height: 30vh;
+  height: 35vh;
   display: flex;
   flex-shrink: 0;
   border-radius: 5px;

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -50,6 +50,25 @@ export interface StudyData {
   admission_date: number;
 }
 
+export interface BookData {
+  id: number;
+  title: string;
+  author: string;
+  seller: number;
+  publisher: string;
+  price: string;
+  origin_imgfile: string;
+  imgfile: string;
+  description: string;
+  damage_level: string;
+  post_date: string;
+  comment: number;
+  is_sold: boolean;
+  school_name: string;
+  major_name: string;
+  admission_date: number;
+}
+
 export interface BookSearchData {
   title: string;
   link: string;
@@ -60,4 +79,16 @@ export interface BookSearchData {
   pubdate: string;
   isbn: string;
   description: string;
+}
+
+export interface BookWriteData {
+  title: string;
+  author: string;
+  seller: number;
+  publisher: string;
+  origin_imgfile: string;
+  price: string;
+  imgfile: File | null;
+  description: string;
+  damage_level: string;
 }


### PR DESCRIPTION
1. 중고거래 api 연결
  - 중고거래 등록된 전체 데이터 get 연결
  - 책 판매하기 post 연결
  - 중고거래 상세보기, 책 판매자 컴포넌트 api 연결
  - 중고거래에 필요한 데이터 타입 추가
  - 중고거래 판매를 위해 작성된 데이터 저장을 위한 recoil 추가
 
2. 커뮤니티 글 검색 api 연결

3. 스터디 글 검색 api 연결
  - searchText props추가 및 연결
  - searchText 저장을 위한 onSearchChange props 추가
 
4. 스터디 상세보기, 중고거래 스타일 오류 해결 