### PR TITLE
[FE-UPDATE] 스터디 글 post api 연결, 중고거래 검색, 판매완료 변경 api 연결

### DIFF
--- a/src/api/postData.tsx
+++ b/src/api/postData.tsx
@@ -5,14 +5,14 @@ const API_BASE_URL = "http://3.35.123.253/api";
 export const postData = async (endpoint: string, data: any) => {
   try {
     const response = await axios.post(`${API_BASE_URL}${endpoint}`, data);
-    console.log("서버로부터의 응답:", response.data);
+    // console.log("서버로부터의 응답:", response.data);
     return response.data;
   } catch (error) {
     console.log(error);
   }
 };
 
-// 토큰을 포함한 상태에서 post 요청 메소드
+// 토큰을 포함한 상태에서 이미지 포함한 post 요청 메소드
 export const postTokenData = async (endpoint: string, formData: FormData) => {
   const storedAuth = localStorage.getItem("auth");
   const auth = storedAuth ? JSON.parse(storedAuth) : null;
@@ -32,6 +32,40 @@ export const postTokenData = async (endpoint: string, formData: FormData) => {
       },
     });
 
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const postTextData = async (endpoint: string, data: any) => {
+  const storedAuth = localStorage.getItem("auth");
+  const auth = storedAuth ? JSON.parse(storedAuth) : null;
+  const accessToken = auth ? auth.access_token : null;
+  const userId = auth ? auth.user_id : null;
+  const postData = { ...data, user_id: userId };
+  try {
+    const response = await axios.post(`${API_BASE_URL}${endpoint}`, postData, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const postSold = async (endpoint: string) => {
+  const storedAuth = localStorage.getItem("auth");
+  const auth = storedAuth ? JSON.parse(storedAuth) : null;
+  const accessToken = auth ? auth.access_token : null;
+  try {
+    const response = await axios.post(`${API_BASE_URL}${endpoint}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
     return response.data;
   } catch (error) {
     console.log(error);

--- a/src/components/study/StudyDetail.tsx
+++ b/src/components/study/StudyDetail.tsx
@@ -54,7 +54,10 @@ const StudyDetail = () => {
             {selectedData.is_recruited === false ? "모집중" : "모집완료"}
           </div>
         </div>
-        <div className="middle">{selectedData.contents}</div>
+        <div
+          className="middle"
+          dangerouslySetInnerHTML={{ __html: selectedData.contents }}
+        ></div>
         <div className="study-bottom">
           {selectedData.hashtags.map((item, index) => (
             <span key={index} className="category">

--- a/src/components/study/StudyList.tsx
+++ b/src/components/study/StudyList.tsx
@@ -54,6 +54,12 @@ const StudyList: React.FC<StudySearchProps> = ({
     navigate("/study/write");
   };
 
+  const stripHtmlTags = (htmlString: string) => {
+    const tempDiv = document.createElement("div");
+    tempDiv.innerHTML = htmlString;
+    return tempDiv.textContent || tempDiv.innerText || "";
+  };
+
   return (
     <div>
       <div className="study-list-top">
@@ -98,7 +104,7 @@ const StudyList: React.FC<StudySearchProps> = ({
             </span>
             {item.title}
           </h1>
-          <p>{item.contents}</p>
+          <p>{stripHtmlTags(item.contents)}</p>
           {item.hashtags.map((hashtag, index) => (
             <span className="category" key={index}>
               # {hashtag}

--- a/src/components/study/StudyWrite.tsx
+++ b/src/components/study/StudyWrite.tsx
@@ -1,7 +1,8 @@
 import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
-import { useState } from "react";
 import "../../styles/study/StudyWrite.scss";
+import { useState } from "react";
+import { postTextData } from "../../api/postData";
 
 const StudyWrite = () => {
   const modules = {
@@ -9,7 +10,7 @@ const StudyWrite = () => {
       [{ header: [1, 2, 3, false] }],
       ["bold", "italic", "underline", "strike"],
       [{ list: "ordered" }, { list: "bullet" }],
-      ["blockquote", "link", "image"],
+      ["blockquote", "link"],
       [{ align: [] }, { color: [] }, { background: [] }],
     ],
   };
@@ -24,12 +25,13 @@ const StudyWrite = () => {
     "bullet",
     "blockquote",
     "link",
-    "image",
     "align",
     "color",
     "background",
   ];
 
+  const [title, setTitle] = useState("");
+  const [contents, setContents] = useState("");
   const [hashtags, setHashtags] = useState<string[]>([]);
   const [currentHashtag, setCurrentHashtag] = useState<string>("");
 
@@ -59,6 +61,21 @@ const StudyWrite = () => {
     setHashtags(updatedHashtags);
   };
 
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const postData = {
+      title,
+      contents,
+      hashtags,
+    };
+
+    console.log(postData);
+    const response = await postTextData("/studys/posts/create/", postData);
+    if (response) {
+      console.log("성공");
+    }
+  };
+
   return (
     <div className="study-write-container">
       <h1>✏️ 스터디 모집 글 작성</h1>
@@ -68,8 +85,15 @@ const StudyWrite = () => {
           className="title"
           type="text"
           placeholder="제목의 핵심 내용을 요약해주세요."
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
         />
-        <ReactQuill modules={modules} formats={formats} />
+        <ReactQuill
+          modules={modules}
+          formats={formats}
+          value={contents}
+          onChange={setContents}
+        />
         <div className="hashtags">
           {hashtags.map((tag, index) => (
             <span key={index} className="category">
@@ -92,7 +116,7 @@ const StudyWrite = () => {
         </div>
         <div className="button">
           <button>취소</button>
-          <button>등록</button>
+          <button onClick={handleSubmit}>등록</button>
         </div>
       </form>
     </div>

--- a/src/components/trade/TradeAll.tsx
+++ b/src/components/trade/TradeAll.tsx
@@ -7,17 +7,25 @@ import { useNavigate } from "react-router-dom";
 import { fetchData } from "../../api/fetchData";
 import { BookData } from "../../types/Types";
 
-const TradeAll = () => {
+interface TradeSearchProps {
+  searchText: string;
+}
+
+const TradeAll: React.FC<TradeSearchProps> = ({ searchText }) => {
   const [selectedFilter, setSelectedFilter] = useState("all");
   const [bookData, setBookData] = useState<BookData[]>([]);
 
   useEffect(() => {
     const fetchBookData = async () => {
-      const data = await fetchData("/usedbooktrades/posts/");
+      let endpoint = "/usedbooktrades/posts/";
+      if (searchText.trim() !== "") {
+        endpoint = `/usedbooktrades/posts/search/?keyword=${searchText}`;
+      }
+      const data = await fetchData(endpoint);
       setBookData(data);
     };
     fetchBookData();
-  }, []);
+  }, [searchText]);
 
   const handleFilterChange = (filter: any) => {
     setSelectedFilter(filter);

--- a/src/components/trade/TradeDetail.tsx
+++ b/src/components/trade/TradeDetail.tsx
@@ -11,11 +11,15 @@ import { useParams } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { BookData } from "../../types/Types";
 import { fetchData } from "../../api/fetchData";
+import { postSold } from "../../api/postData";
 
 const TradeDetail = () => {
   const { tradeId } = useParams();
   const parsedTradeId = tradeId ? parseInt(tradeId) : undefined;
   const [selectedData, setSelectedData] = useState<BookData>();
+  const storedAuth = localStorage.getItem("auth");
+  const auth = storedAuth ? JSON.parse(storedAuth) : null;
+  const userId = auth ? auth.user_id : null;
 
   useEffect(() => {
     const fetchCommunityData = async () => {
@@ -29,6 +33,13 @@ const TradeDetail = () => {
   if (!selectedData) {
     return <div>해당 컨텐츠를 찾을 수 없습니다.</div>;
   }
+
+  const handleSellBtnClick = async (id: number) => {
+    const response = await postSold(`/usedbooktrades/book/${id}/sold/`);
+    if (response) {
+      alert("판매완료되었습니다.");
+    }
+  };
   // const commentData = selectedData?.comments || [];
 
   return (
@@ -38,6 +49,22 @@ const TradeDetail = () => {
           <span className={selectedData.is_sold ? "sold-out" : "selling"}>
             {selectedData.is_sold ? "판매완료" : "판매중"}
           </span>
+          {selectedData.user_id === userId && !selectedData.is_sold && (
+            <button
+              className="sold-out"
+              onClick={() => handleSellBtnClick(selectedData.id)}
+            >
+              판매완료하기
+            </button>
+          )}
+          {/* {selectedData.user_id === userId && selectedData.is_sold && (
+            <button
+              className="selling"
+              onClick={() => handleSellBtnClick(selectedData.id)}
+            >
+              판매중으로 변경
+            </button>
+          )} */}
         </div>
         <div className="middle">
           <div className="img">

--- a/src/components/trade/TradeSearch.tsx
+++ b/src/components/trade/TradeSearch.tsx
@@ -1,6 +1,7 @@
 import { ReactComponent as SearchIcon } from "../../assets/icon/search.svg";
 import { ReactComponent as PencilIcon } from "../../assets/icon/pencil.svg";
 import styled from "styled-components";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 const SearchBox = styled.div`
@@ -27,16 +28,40 @@ const RegisterBtn = styled.button`
   margin-left: auto;
 `;
 
-const TradeSearch = () => {
+interface TradeSearchProps {
+  searchText: string;
+  onSearchChange: (filter: string) => void;
+}
+
+const TradeSearch: React.FC<TradeSearchProps> = ({ onSearchChange }) => {
+  const [searchText, setSearchText] = useState<string>("");
   const navigate = useNavigate();
+
+  const handleInputChange = (event: any) => {
+    setSearchText(event.target.value);
+  };
+
+  const handleSearch = () => {
+    if (searchText.trim() !== "") {
+      onSearchChange(searchText);
+    }
+    setSearchText("");
+  };
   const goWrite = () => {
     navigate("/trade/write");
   };
+
   return (
     <div>
       <SearchBox>
-        <input type="text" placeholder="제목, 저자, 출판사" />
-        <SearchIcon />
+        <input
+          type="text"
+          placeholder="제목, 저자, 출판사"
+          value={searchText}
+          onChange={handleInputChange}
+          onSubmit={handleSearch}
+        />
+        <SearchIcon onClick={handleSearch} />
       </SearchBox>
       <RegisterBtn onClick={goWrite}>
         <PencilIcon />책 판매하기

--- a/src/pages/trade/TradeApp.tsx
+++ b/src/pages/trade/TradeApp.tsx
@@ -6,6 +6,7 @@ import TradeDetail from "../../components/trade/TradeDetail";
 import TradeSaler from "../../components/trade/TradeSaler";
 import TradeWrite from "../../components/trade/TradeWrite";
 import styled from "styled-components";
+import { useState } from "react";
 import { Routes, Route } from "react-router-dom";
 
 const TradeContainer = styled.div`
@@ -20,6 +21,7 @@ const TradeContent = styled.div`
 `;
 
 const TradeApp = () => {
+  const [searchText, setSearchText] = useState("");
   return (
     <Routes>
       <Route
@@ -27,9 +29,12 @@ const TradeApp = () => {
         element={
           <TradeContainer>
             <TradeContent>
-              <TradeSearch />
+              <TradeSearch
+                searchText={searchText}
+                onSearchChange={setSearchText}
+              />
               <TradeToday />
-              <TradeAll />
+              <TradeAll searchText={searchText} />
             </TradeContent>
             <TradePrice />
           </TradeContainer>

--- a/src/styles/study/StudyWrite.scss
+++ b/src/styles/study/StudyWrite.scss
@@ -60,6 +60,14 @@
           max-width: 100%;
           max-height: 30vh;
         }
+
+        ol,
+        ul {
+          padding-left: 10px;
+          li {
+            font-size: 1rem;
+          }
+        }
       }
 
       p {

--- a/src/styles/trade/TradeDetail.scss
+++ b/src/styles/trade/TradeDetail.scss
@@ -7,7 +7,11 @@
   box-shadow: 2px 2px 4px 0px #00000040;
   .top {
     margin: 10px 0 20px 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     span {
+      height: 4vh;
       border-radius: 15px;
       color: #ffffff;
       font-size: 1rem;
@@ -19,6 +23,21 @@
     }
     .sold-out {
       background: #cccccc;
+    }
+
+    button {
+      height: 4vh;
+      border-radius: 5px;
+      color: #ffffff;
+      font-weight: 700;
+
+      .sold-out {
+        background: #cccccc;
+      }
+
+      .selling {
+        background: #1b1c3a;
+      }
     }
   }
 

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -52,6 +52,7 @@ export interface StudyData {
 
 export interface BookData {
   id: number;
+  user_id: number;
   title: string;
   author: string;
   seller: number;


### PR DESCRIPTION
1. 스터디 글 post api 연결
  - text 데이터, 토큰 전달용을 위한 메서드 추가
  - post api 연결
  - 스터디 리스트에서 contents 출력시 태그 삭제되어 보이도록 수정
  - 스터디 상세보기에서 contents 출력시 태그 적용되어 보이도록 수정
  
2. 중고거래 검색 api 연결
  - 검색 값 props로 전달을 위해 searchText 추가

3. 중고거래 판매완료 변경 api 연결
  - 로컬에서 userId와 판매 데이터에서 user_id 비교한 조건문 적용
  - 판매자에게만 보이도록 판매완료하기 버튼 생성
  - 버튼 클릭시 api 연결해 판매완료로  변경